### PR TITLE
When nothing is written this is not an error

### DIFF
--- a/src/Listener/FailedStepListener.php
+++ b/src/Listener/FailedStepListener.php
@@ -125,7 +125,7 @@ class FailedStepListener implements EventSubscriberInterface
     {
         $path = sprintf("%s/behat-%s.%s", $this->logDirectory, $this->currentDateAsString, $type);
 
-        if (!file_put_contents($path, $content)) {
+        if (is_bool(file_put_contents($path, $content))) {
             throw new \RuntimeException(sprintf('Failed while trying to write log in "%s".', $path));
         }
     }


### PR DESCRIPTION
The PHP file_put_contents function returns false on error and otherwise the amount of bytes written. If the content is empty but the process was successful, the function still throws an error because nothing was written. 

Checking if the function returns a boolean function returns a boolean, fixes the problem.