### PR TITLE
When nothing is written this is not an error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,6 @@ before_script:
 
 script:
     - composer validate --strict
-
     - vendor/bin/phpspec run
-    - vendor/bin/behat --strict || vendor/bin/behat --strict --rerun
+    - vendor/bin/behat --strict -vv || vendor/bin/behat --strict --rerun
+    - ls -lah test-application/logs

--- a/src/Listener/FailedStepListener.php
+++ b/src/Listener/FailedStepListener.php
@@ -125,7 +125,12 @@ class FailedStepListener implements EventSubscriberInterface
     {
         $path = sprintf("%s/behat-%s.%s", $this->logDirectory, $this->currentDateAsString, $type);
 
-        if (!file_put_contents($path, $content)) {
+        if(empty($content)) {
+            throw new \Exception("test");
+            
+        }
+
+        if (file_put_contents($path, $content) === false) {
             throw new \RuntimeException(sprintf('Failed while trying to write log in "%s".', $path));
         }
     }


### PR DESCRIPTION
The PHP file_put_contents function returns false on error and otherwise the amount of bytes written. If the content is empty but the process was successful, the function still throws an error because nothing was written.

Checking if the function returns a boolean function returns a boolean, fixes the problem.

Replaces #29 