### PR TITLE
allow log content to be empty

### DIFF
--- a/src/Listener/FailedStepListener.php
+++ b/src/Listener/FailedStepListener.php
@@ -101,7 +101,7 @@ final class FailedStepListener implements EventSubscriberInterface
     {
         $path = sprintf("%s/behat-%s.%s", $this->logDirectory, $this->currentDateAsString, $type);
 
-        if (!file_put_contents($path, $content)) {
+        if (file_put_contents($path, $content) === false) {
             throw new \RuntimeException(sprintf('Failed while trying to write log in "%s".', $path));
         }
     }


### PR DESCRIPTION
Current implementation for case when log content is empty is throwing exception. This is false positive that is providing user with wrong info.

I had this issue and lost quite some time changing folder permissions although real reason was `file_put_contents` returning 0 because 0 bytes were written to disc.

And so confusing exception was presented about failing to write file although file is created. It's just empty.