### PR TITLE
Proposal: Return the OuterHtml of the page for `getResponseContentLogMessage`

### DIFF
--- a/src/Listener/FailedStepListener.php
+++ b/src/Listener/FailedStepListener.php
@@ -148,7 +148,7 @@ final class FailedStepListener implements EventSubscriberInterface
     private function getResponseContentLogMessage(Session $session): ?string
     {
         try {
-            return 'Response content:' . "\n" . $session->getPage()->getContent() . "\n";
+            return 'Response content:' . "\n" . $session->getPage()->getOuterHtml() . "\n";
         } catch (MinkException | WebDriverException | StreamReadException $exception) {
             return null;
         }


### PR DESCRIPTION
First of all thanks for all the hard work going on to this!

I've got a proposal, I'm not sure if it's favorable or if there is anything missing.

When using `$session->getPage()->getContent()` we're basically omitting the `<html>` tag from the actual log message. 

There are scenario's where there is useful information added to that tag. Using getOuterHtml will actually ensure it is rendered.

With `getContent` in place:
![before](https://github.com/FriendsOfBehat/MinkDebugExtension/assets/16667281/366411e4-1ae6-4b31-933b-5ba7ae6f3386)

with `getOuterHtml` in place
![after](https://github.com/FriendsOfBehat/MinkDebugExtension/assets/16667281/51b05717-72fa-436b-a18a-83d476f9b1fe)


